### PR TITLE
better solution for executing bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-BASH = /usr/bin/bash
-SHELL := $(BASH)
+SHELL := bash
 
-install = install -D --mode=$(1) <(sed -e "s|@bash@|$(BASH)|g" $(2)) $(DESTDIR)$(3)/$(2:.in=)
+BASH_FROM_ENV = /usr/bin/env bash
+install = install -D --mode=$(1) <(sed -e "s|@bash@|$(BASH_FROM_ENV)|g" $(2)) $(DESTDIR)$(3)/$(2:.in=)
 
 .PHONY: install
 install:


### PR DESCRIPTION
I don't have bash at `/usr/bin/bash`. In my ubuntu bash is located at `/bin/bash`. So xlogin didn't work for me at first.

But with this simple change everything worked flawlessly ^_^

Using `/usr/bin/env` in shebangs is a good practice. Please accept this.

Here's a cat photo. Just in case :3
<img width="186" alt="2016-09-14 22 50 36" src="https://cloud.githubusercontent.com/assets/588262/18527516/c961cc3c-7acd-11e6-82b5-c76497c657f1.png">
